### PR TITLE
fix: added `shell:true` option to `spawnSync`

### DIFF
--- a/serverless-single-page-app-plugin/index.js
+++ b/serverless-single-page-app-plugin/index.js
@@ -44,7 +44,7 @@ class ServerlessPlugin {
     if (this.serverless.variables.service.provider.profile) {
       command = `${command} --profile ${this.serverless.variables.service.provider.profile}`;
     }
-    const result = spawnSync(command, args);
+    const result = spawnSync(command, args, { shell: true });
 
     const stdout = typeof result.stdout === 'string' ? result.stdout : result.stdout && result.stdout.toString() ;
     const sterr = typeof result.stderr === 'string' ? result.stderr : result.stderr && result.stderr.toString();


### PR DESCRIPTION
This change is a mirror of the fix introduced in the original repository
https://github.com/serverless/examples/pull/641

Without the fix `invalidateCloudFrontCache` command doesn't seem to work, i,e. no JSON output is visible in the terminal and no distribution invalidation is created in AWS console
![image](https://user-images.githubusercontent.com/4612163/219173222-5d46962b-132a-4219-b2d4-d0ea88c0a041.png)

When the fix is in place, there's a JSON output:
![image](https://user-images.githubusercontent.com/4612163/219173532-e7c9d7ca-bc9e-4a88-bf27-37a4d0b2f1b9.png)
and the invalidation is visible in AWS console
